### PR TITLE
twres: Clean up header clutter and introduce dynamic custom status bar

### DIFF
--- a/recovery/root/twres/portrait.xml
+++ b/recovery/root/twres/portrait.xml
@@ -4026,7 +4026,10 @@
 					</actions>
 				</listitem>
 				<listitem name="Windows Tools page">
-				<action function="page">wintools</action>
+					<actions>
+						<action function="set">show_cluttered_Wbar=1</action>
+						<action function="page">wintools</action>
+					</actions>
 				</listitem>
 				<listitem name="Rotate Screen to Landscape">
 				<action function="rotationbyarkt"/>
@@ -5724,6 +5727,20 @@
 		</page>
 
 		<page name="slideout">
+			<fill color="%accent_color%">
+				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
+			</fill>
+			
+			<fill color="#00000030">
+				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
+			</fill>
+			
+			<text color="%text_color%">
+				<font resource="font_m"/>
+				<placement x="%indent%" y="7"/>
+				<text>{@cpu_temp=CPU: %tw_cpu_temp% °C} | ESP: %arkt_esppart_display% | WIN: %arkt_winpart_display% | UD: %arkt_userdatapart_display% | %tw_time% | Battery: %tw_battery%</text>
+			</text>
+
 			<fill color="%background_color%">
 				<placement x="0" y="%row2_header_y%" w="%screen_width%" h="%slideout_bg_height%"/>
 			</fill>
@@ -5746,6 +5763,16 @@
 			<action>
 				<touch key="power+voldown"/>
 				<action function="screenshot"/>
+			</action>
+
+			<action>
+				<touch key="back"/>
+				<action function="overlay"/>
+			</action>
+
+			<action>
+				<touch key="home"/>
+				<action function="overlay"/>
 			</action>
 		</page>
 
@@ -5903,12 +5930,18 @@
 
 			<action>
 				<touch key="back"/>
-				<action function="page">main</action>
+				<actions>
+					<action function="set">show_cluttered_Wbar=0</action>
+					<action function="page">main</action>
+				</actions>
 			</action>
 
 			<action>
 				<touch key="home"/>
-				<action function="page">main</action>
+				<actions>
+					<action function="set">show_cluttered_Wbar=0</action>
+					<action function="page">main</action>
+				</actions>
 			</action>
 		</page>
 

--- a/recovery/root/twres/twres-arkt/landscape.xml
+++ b/recovery/root/twres/twres-arkt/landscape.xml
@@ -3903,7 +3903,10 @@
 					</actions>
 				</listitem>
 				<listitem name="Windows Tools page">
-				<action function="page">wintools</action>
+					<actions>
+						<action function="set">show_cluttered_Wbar=1</action>
+						<action function="page">wintools</action>
+					</actions>
 				</listitem>
 				<listitem name="Rotate Screen to Portrait">
 				<action function="rotationbyarkt"/>
@@ -5772,6 +5775,42 @@ edi				<conditions>
 		</page>
 
 		<page name="slideout">
+			<fill color="%accent_color%">
+				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
+			</fill>
+			
+			<fill color="#00000030">
+				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
+			</fill>
+			
+			<text color="%text_color%">
+				<font resource="font_s"/>
+				<placement x="%indent%" y="3"/>
+				<text>{@cpu_temp=CPU: %tw_cpu_temp% °C}    ESP: %arkt_esppart_display%    WIN: %arkt_winpart_display%    DATA: %arkt_userdatapart_display%    </text>
+			</text>
+
+			<text color="%text_color%">
+				<conditions>
+					<condition var1="tw_clock_12_pos_x" var2="0"/>
+					<condition var1="tw_clock_24_pos_x" var2="0"/>
+				</conditions>
+				<font resource="font_s"/>
+				<placement x="%center_x%" y="3" placement="5"/>
+				<text>%tw_time%</text>
+			</text>
+
+			<text color="%text_color%">
+				<conditions>
+					<condition var1="tw_no_battery_percent" var2="0"/>
+					<condition var1="tw_battery" op="&gt;" var2="0"/>
+					<condition var1="tw_battery" op="&lt;" var2="101"/>
+					<condition var1="tw_battery_pos_x" var2="0"/>
+				</conditions>
+				<font resource="font_s"/>
+				<placement x="%indent_right%" y="3" placement="1"/>
+				<text>{@battery_pct=Battery: %tw_battery%}</text>
+			</text>
+
 			<fill color="%background_color%">
 				<placement x="0" y="%row2_header_y%" w="%screen_width%" h="%slideout_bg_height%"/>
 			</fill>
@@ -5794,6 +5833,16 @@ edi				<conditions>
 			<action>
 				<touch key="power+voldown"/>
 				<action function="screenshot"/>
+			</action>
+
+			<action>
+				<touch key="back"/>
+				<action function="overlay"/>
+			</action>
+
+			<action>
+				<touch key="home"/>
+				<action function="overlay"/>
 			</action>
 		</page>
 
@@ -6062,12 +6111,18 @@ edi				<conditions>
 
 			<action>
 				<touch key="back"/>
-				<action function="page">main</action>
+				<actions>
+					<action function="set">show_cluttered_Wbar=0</action>
+					<action function="page">main</action>
+				</actions>
 			</action>
 
 			<action>
 				<touch key="home"/>
-				<action function="page">main</action>
+				<actions>
+					<action function="set">show_cluttered_Wbar=0</action>
+					<action function="page">main</action>
+				</actions>
 			</action>
 		</page>
 

--- a/recovery/root/twres/twres-arkt/ui.xml
+++ b/recovery/root/twres/twres-arkt/ui.xml
@@ -235,6 +235,7 @@
 		<variable name="tw_clock_24_pos_x" value="0"/>
 		<variable name="tw_cpu_pos_x" value="0"/>
 		<variable name="tw_battery_pos_x" value="0"/>
+		<variable name="show_cluttered_Wbar" value="0"/>
 	</variables>
 
 	<mousecursor>
@@ -275,6 +276,7 @@
 				<condition var1="tw_busy" var2="0"/>
 				<placement x="1770" y="46"/>
 				<actions>
+					<action function="set">show_cluttered_Wbar=1</action>
 					<action function="page">wintools</action>
 				</actions>
 			</button>
@@ -289,18 +291,57 @@
 				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
 			</fill>
 
+			<button>
+				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
+				<fill color="%transparent%"/>
+				<condition var1="show_cluttered_Wbar" var2="0"/>
+				<action function="set">show_cluttered_Wbar=1</action>
+			</button>
+
+			<button>
+				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
+				<fill color="%transparent%"/>
+				<condition var1="show_cluttered_Wbar" var2="1"/>
+				<action function="set">show_cluttered_Wbar=0</action>
+			</button>
+
 			<text color="%text_color%">
-				<condition var1="tw_no_cpu_temp" var2="1"/>
-				<condition var1="tw_cpu_pos_x" var2="0"/>
-				<font resource="font_m"/>
-				<placement x="%indent%" y="%row1_header_y%"/>
+				<conditions>
+					<condition var1="show_cluttered_Wbar" var2="0"/>
+					<condition var1="tw_no_cpu_temp" var2="1"/>
+					<condition var1="tw_cpu_pos_x" var2="0"/>
+				</conditions>
+				<font resource="font_s"/>
+				<placement x="%indent%" y="3"/>
 				<text>%tw_version%</text>
 			</text>
 
 			<text color="%text_color%">
-				<font resource="font_m"/>
-				<placement x="%indent%" y="%row1_header_y%"/>
-				<text>{@cpu_temp=CPU: %tw_cpu_temp% °C}    ESP: %arkt_esppart_display%    WIN: %arkt_winpart_display%    DATA: %arkt_userdatapart_display%    %tw_time%</text>
+				<conditions>
+					<condition var1="show_cluttered_Wbar" var2="0"/>
+					<condition var1="tw_no_cpu_temp" var2="0"/>
+					<condition var1="tw_cpu_pos_x" var2="0"/>
+				</conditions>
+				<font resource="font_s"/>
+				<placement x="%indent%" y="3"/>
+				<text>{@cpu_temp=CPU: %tw_cpu_temp% °C}</text>
+			</text>
+
+			<text color="%text_color%">
+				<condition var1="show_cluttered_Wbar" var2="1"/>
+				<font resource="font_s"/>
+				<placement x="%indent%" y="3"/>
+				<text>{@cpu_temp=CPU: %tw_cpu_temp% °C}    ESP: %arkt_esppart_display%    WIN: %arkt_winpart_display%    DATA: %arkt_userdatapart_display%    </text>
+			</text>
+
+			<text color="%text_color%">
+				<conditions>
+					<condition var1="tw_clock_12_pos_x" var2="0"/>
+					<condition var1="tw_clock_24_pos_x" var2="0"/>
+				</conditions>
+				<font resource="font_s"/>
+				<placement x="%center_x%" y="3" placement="5"/>
+				<text>%tw_time%</text>
 			</text>
 
 			<text color="%text_color%">
@@ -310,8 +351,8 @@
 					<condition var1="tw_battery" op="&lt;" var2="101"/>
 					<condition var1="tw_battery_pos_x" var2="0"/>
 				</conditions>
-				<font resource="font_m"/>
-				<placement x="%indent_right%" y="%row1_header_y%" placement="1"/>
+				<font resource="font_s"/>
+				<placement x="%indent_right%" y="3" placement="1"/>
 				<text>{@battery_pct=Battery: %tw_battery%}</text>
 			</text>
 

--- a/recovery/root/twres/ui.xml
+++ b/recovery/root/twres/ui.xml
@@ -232,6 +232,7 @@
 		<variable name="tw_clock_24_pos_x" value="0"/>
 		<variable name="tw_cpu_pos_x" value="0"/>
 		<variable name="tw_battery_pos_x" value="0"/>
+		<variable name="show_cluttered_Wbar" value="0"/>
 	</variables>
 
 	<mousecursor>
@@ -272,6 +273,7 @@
 				<condition var1="tw_busy" var2="0"/>
 				<placement x="936" y="88"/>
 				<actions>
+					<action function="set">show_cluttered_Wbar=1</action>
 					<action function="page">wintools</action>
 				</actions>
 			</button>
@@ -286,17 +288,70 @@
 				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
 			</fill>
 
+			<button>
+				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
+				<fill color="%transparent%"/>
+				<condition var1="show_cluttered_Wbar" var2="0"/>
+				<action function="set">show_cluttered_Wbar=1</action>
+			</button>
+
+			<button>
+				<placement x="0" y="0" w="%screen_width%" h="%status_height%"/>
+				<fill color="%transparent%"/>
+				<condition var1="show_cluttered_Wbar" var2="1"/>
+				<action function="set">show_cluttered_Wbar=0</action>
+			</button>
+
 			<text color="%text_color%">
-				<condition var1="tw_no_cpu_temp" var2="1"/>
-				<condition var1="tw_cpu_pos_x" var2="0"/>
-				<font resource="font_m"/>
-				<placement x="%indent%" y="%row1_header_y%"/>
+				<conditions>
+					<condition var1="show_cluttered_Wbar" var2="0"/>
+					<condition var1="tw_no_cpu_temp" var2="1"/>
+					<condition var1="tw_cpu_pos_x" var2="0"/>
+				</conditions>
+				<font resource="font_s"/>
+				<placement x="%indent%" y="7"/>
 				<text>%tw_version%</text>
 			</text>
 
 			<text color="%text_color%">
+				<conditions>
+					<condition var1="show_cluttered_Wbar" var2="0"/>
+					<condition var1="tw_no_cpu_temp" var2="0"/>
+					<condition var1="tw_cpu_pos_x" var2="0"/>
+				</conditions>
+				<font resource="font_s"/>
+				<placement x="%indent%" y="9"/>
+				<text>{@cpu_temp=CPU: %tw_cpu_temp% °C}</text>
+			</text>
+
+			<text color="%text_color%">
+				<conditions>
+					<condition var1="show_cluttered_Wbar" var2="0"/>
+					<condition var1="tw_clock_12_pos_x" var2="0"/>
+					<condition var1="tw_clock_24_pos_x" var2="0"/>
+				</conditions>
+				<font resource="font_s"/>
+				<placement x="%center_x%" y="9" placement="5"/>
+				<text>%tw_time%</text>
+			</text>
+
+			<text color="%text_color%">
+				<conditions>
+					<condition var1="show_cluttered_Wbar" var2="0"/>
+					<condition var1="tw_no_battery_percent" var2="0"/>
+					<condition var1="tw_battery" op="&gt;" var2="0"/>
+					<condition var1="tw_battery" op="&lt;" var2="101"/>
+					<condition var1="tw_battery_pos_x" var2="0"/>
+				</conditions>
+				<font resource="font_s"/>
+				<placement x="%indent_right%" y="9" placement="1"/>
+				<text>{@battery_pct=Battery: %tw_battery%}</text>
+			</text>
+
+			<text color="%text_color%">
+				<condition var1="show_cluttered_Wbar" var2="1"/>
 				<font resource="font_m"/>
-				<placement x="%indent%" y="%row1_header_y%"/>
+				<placement x="%indent%" y="7"/>
 				<text>{@cpu_temp=CPU: %tw_cpu_temp% °C} | ESP: %arkt_esppart_display% | WIN: %arkt_winpart_display% | UD: %arkt_userdatapart_display% | %tw_time% | Battery: %tw_battery%</text>
 			</text>
 


### PR DESCRIPTION
- nuke the cluttered heavy status bar by default for a clean UI
- Tap the header to manually toggle detailed partition stats
- Auto-expands detailed view on console and Windows Tools page